### PR TITLE
fix(search): batch initial Insights call with Search call

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,10 +43,10 @@
     "instantsearch.css": "^7.4.5",
     "instantsearch.js": "^4.41.0",
     "preact": "^10.7.3",
-    "react": "^18.1.0",
-    "react-dom": "^18.1.0",
-    "react-instantsearch-hooks": "^6.27.0",
-    "react-instantsearch-hooks-web": "^6.27.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-instantsearch-hooks": "^6.28.0",
+    "react-instantsearch-hooks-web": "^6.28.0",
     "serve-static": "^1.14.1"
   },
   "author": "qinglin.ye@algolia.com"

--- a/src/components/search/AlgoliaInsights.client.jsx
+++ b/src/components/search/AlgoliaInsights.client.jsx
@@ -3,50 +3,14 @@
  * https://www.algolia.com/doc/api-reference/widgets/insights/react-hooks/?client=js
  */
 import {createInsightsMiddleware} from 'instantsearch.js/es/middlewares';
-import {useEffect} from 'react';
-import {useConnector} from 'react-instantsearch-hooks-web';
+import {useLayoutEffect} from 'react';
+import {useInstantSearch} from 'react-instantsearch-hooks-web';
 import algoConfig from '../../../algolia.config.json';
 
-const connectMiddleware = (renderFn, unmountFn) => (widgetParams) => ({
-  init(initOptions) {
-    renderFn(
-      {
-        ...this.getWidgetRenderState(initOptions),
-        instantSearchInstance: initOptions.instantSearchInstance,
-      },
-      true,
-    );
-  },
-
-  render(renderOptions) {
-    const renderState = this.getWidgetRenderState(renderOptions);
-
-    renderFn(
-      {
-        ...renderState,
-        instantSearchInstance: renderOptions.instantSearchInstance,
-      },
-      false,
-    );
-  },
-
-  getWidgetRenderState(renderOptions) {
-    return {
-      use: (...args) => renderOptions.instantSearchInstance.use(...args),
-      unuse: (...args) => renderOptions.instantSearchInstance.unuse(...args),
-      widgetParams,
-    };
-  },
-
-  dispose() {
-    unmountFn();
-  },
-});
-
 export function Insights() {
-  const {use} = useConnector(connectMiddleware);
+  const {use} = useInstantSearch();
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     const insightsClient = window.aa;
     insightsClient('init', {
       appId: algoConfig.appId,
@@ -57,7 +21,7 @@ export function Insights() {
       insightsClient,
     });
 
-    use(middleware);
+    return use(middleware);
   }, [use]);
 
   return null;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3848,13 +3848,13 @@ rc@^1.2.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-dom@^18.1.0:
-  version "18.1.0"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-18.1.0.tgz#7f6dd84b706408adde05e1df575b3a024d7e8a2f"
-  integrity sha512-fU1Txz7Budmvamp7bshe4Zi32d0ll7ect+ccxNu9FlObT605GOEB8BfO4tmRJ39R5Zj831VCpvQ05QPBW5yb+w==
+react-dom@^18.2.0:
+  version "18.2.0"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-18.2.0.tgz#22aaf38708db2674ed9ada224ca4aa708d821e3d"
+  integrity sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==
   dependencies:
     loose-envify "^1.1.0"
-    scheduler "^0.22.0"
+    scheduler "^0.23.0"
 
 react-error-boundary@^3.1.3:
   version "3.1.4"
@@ -3879,19 +3879,19 @@ react-helmet-async@^1.2.3:
     react-fast-compare "^3.2.0"
     shallowequal "^1.1.0"
 
-react-instantsearch-hooks-web@^6.27.0:
-  version "6.27.0"
-  resolved "https://registry.yarnpkg.com/react-instantsearch-hooks-web/-/react-instantsearch-hooks-web-6.27.0.tgz#43c63d2ffa37b238c2160bbb4f8018b946db575d"
-  integrity sha512-MqkPgocOHWEMDoJXno8KeRzNSKHxqT7cgXSvqSmtj5W75KN/QB/dzkXYwli7c422hlv+jak0B2mPp2mUHqjGYQ==
+react-instantsearch-hooks-web@^6.28.0:
+  version "6.28.0"
+  resolved "https://registry.yarnpkg.com/react-instantsearch-hooks-web/-/react-instantsearch-hooks-web-6.28.0.tgz#49b17edd0ba891a095f6a43b5b42a25128e27ae7"
+  integrity sha512-ye7TpcNotK/uslFd6jdEGZb3URpyoZfH95EgDRb238uvZZAt2YIy/IC2AwxnFD6L2HMBKbtOW9CPZLd3S/1viA==
   dependencies:
     "@babel/runtime" "^7.1.2"
     instantsearch.js "^4.41.0"
-    react-instantsearch-hooks "6.27.0"
+    react-instantsearch-hooks "6.28.0"
 
-react-instantsearch-hooks@6.27.0, react-instantsearch-hooks@^6.27.0:
-  version "6.27.0"
-  resolved "https://registry.yarnpkg.com/react-instantsearch-hooks/-/react-instantsearch-hooks-6.27.0.tgz#b1340a03ec41e4eff0d46b8aee284fa8685dfca6"
-  integrity sha512-AaedA3C4zcGOSm8eGhRqQ5QVhrQwamAU1PAfzXyQQ671v3K5qLAksgUwrZVus/eGuzOylBf8MOwGrt4nSOtLUQ==
+react-instantsearch-hooks@6.28.0, react-instantsearch-hooks@^6.28.0:
+  version "6.28.0"
+  resolved "https://registry.yarnpkg.com/react-instantsearch-hooks/-/react-instantsearch-hooks-6.28.0.tgz#e71399a715faf2c4045eaafb4ed302610598a879"
+  integrity sha512-CfrAWnhXj6+TtFdUviBiz9r4U9Hwcq3ARstvq98R0X23kMoY8+VzAdTGmfPchxLaadraV8L2XdpclH2bUIYNiQ==
   dependencies:
     "@babel/runtime" "^7.1.2"
     algoliasearch-helper "^3.8.2"
@@ -3908,10 +3908,10 @@ react-refresh@^0.13.0:
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.13.0.tgz#cbd01a4482a177a5da8d44c9755ebb1f26d5a1c1"
   integrity sha512-XP8A9BT0CpRBD+NYLLeIhld/RqG9+gktUjW1FkE+Vm7OCinbG1SshcK5tb9ls4kzvjZr9mOQc7HYgBngEyPAXg==
 
-react@^18.1.0:
-  version "18.1.0"
-  resolved "https://registry.yarnpkg.com/react/-/react-18.1.0.tgz#6f8620382decb17fdc5cc223a115e2adbf104890"
-  integrity sha512-4oL8ivCz5ZEPyclFQXaNksK3adutVS8l2xzZU0cqEFrE9Sb7fC0EFK5uEk74wIreL1DERyjvsU915j1pcT2uEQ==
+react@^18.2.0:
+  version "18.2.0"
+  resolved "https://registry.yarnpkg.com/react/-/react-18.2.0.tgz#555bd98592883255fa00de14f1151a917b5d77d5"
+  integrity sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==
   dependencies:
     loose-envify "^1.1.0"
 
@@ -4064,10 +4064,10 @@ safe-buffer@^5.0.1, safe-buffer@~5.2.0:
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
-scheduler@^0.22.0:
-  version "0.22.0"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.22.0.tgz#83a5d63594edf074add9a7198b1bae76c3db01b8"
-  integrity sha512-6QAm1BgQI88NPYymgGQLCZgvep4FyePDWFpXVK+zNSUgHwlqpJy8VEh8Et0KxTACS4VWwMousBElAZOH9nkkoQ==
+scheduler@^0.23.0:
+  version "0.23.0"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.23.0.tgz#ba8041afc3d30eb206a487b6b384002e4e61fdfe"
+  integrity sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==
   dependencies:
     loose-envify "^1.1.0"
 


### PR DESCRIPTION
This updates the Insights integration in Search to trigger a single network request on initial Search load. This changes `useEffect()` to `useLayoutEffect()` to batch the updates before scheduling a search.

I also updated the middleware integration with the new `useInstantSearch()` Hook introduced in [v6.28.0](https://github.com/algolia/react-instantsearch/releases/tag/v6.28.0).